### PR TITLE
Update to correct pin

### DIFF
--- a/examples/04.Shields/PIR_Shield/pir_simple/pir_simple.ino
+++ b/examples/04.Shields/PIR_Shield/pir_simple/pir_simple.ino
@@ -5,7 +5,7 @@
  * 1 Button Shield pushbutton connects pin D3 to GND
  */
 
-const int PIR = D3;
+const int PIR = D2;
 
 
 int PIRState = 0;


### PR DESCRIPTION
If using I2C port, the PIR sensor is actually connected to D2 (not D3).